### PR TITLE
Bump catt from 0.12.11 to 0.12.12

### DIFF
--- a/custom_components/continuously_casting_dashboards/manifest.json
+++ b/custom_components/continuously_casting_dashboards/manifest.json
@@ -2,7 +2,7 @@
     "domain": "continuously_casting_dashboards",
     "name": "Continuously Cast Dashboards",
     "documentation": "https://github.com/b0mbays/continuously_casting_dashboards",
-    "requirements": ["catt==0.12.11"],
+    "requirements": ["catt==0.12.12"],
     "version": "1.3.2",
     "dependencies": [],
     "codeowners": ["@b0mbays"]


### PR DESCRIPTION
Fixes "missing 1 required keyword-only argument: 'timeout'" issue with media_player.turn_on: https://github.com/home-assistant/core/issues/116766