### PR TITLE
2.0.3

### DIFF
--- a/custom_components/continuously_casting_dashboards/casting.py
+++ b/custom_components/continuously_casting_dashboards/casting.py
@@ -53,8 +53,8 @@ class CastingManager:
             config_volume = device_config.get('volume', None)
             _LOGGER.debug(f"Config volume for {ip}: {config_volume}")
             
-            max_retries = self.config.get('max_retries', DEFAULT_MAX_RETRIES)
-            retry_delay = self.config.get('retry_delay', DEFAULT_RETRY_DELAY)
+            max_retries = 2
+            retry_delay = 5
             verification_wait_time = self.config.get('verification_wait_time', DEFAULT_VERIFICATION_WAIT_TIME)
             
             for attempt in range(max_retries):

--- a/custom_components/continuously_casting_dashboards/const.py
+++ b/custom_components/continuously_casting_dashboards/const.py
@@ -2,6 +2,7 @@
 
 DOMAIN = "continuously_casting_dashboards"
 CONF_SWITCH_ENTITY = "switch_entity_id"
+CONF_SWITCH_ENTITY_STATE = "switch_entity_state"
 PLATFORMS = []
 
 # Default configuration values

--- a/custom_components/continuously_casting_dashboards/device.py
+++ b/custom_components/continuously_casting_dashboards/device.py
@@ -23,14 +23,7 @@ class DeviceManager:
         self.active_checks = {}    # Track active status checks
     
     async def async_get_device_ip(self, device_name_or_ip):
-        """Get IP address for a device name or directly use IP if provided.
-        
-        Arguments:
-            device_name_or_ip: Either a device name like "Kitchen display" or an IP address like "192.168.1.10"
-        
-        Returns:
-            IP address as string or None if not found
-        """
+        """Get IP address for a device name or directly use IP if provided."""
         # Check if the provided value is already an IP address
         if IP_PATTERN.match(device_name_or_ip):
             _LOGGER.info(f"Using direct IP address: {device_name_or_ip}")
@@ -52,12 +45,13 @@ class DeviceManager:
             )
             
             try:
-                stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=20.0)
+                stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=15.0)
             except asyncio.TimeoutError:
-                _LOGGER.warning(f"Scan for device {device_name_or_ip} timed out after 20s")
+                _LOGGER.warning(f"Scan for device {device_name_or_ip} timed out after 15s")
+                # Clean up the process more aggressively
                 process.terminate()
                 try:
-                    await asyncio.wait_for(process.wait(), timeout=5.0)
+                    await asyncio.wait_for(process.wait(), timeout=2.0)
                 except asyncio.TimeoutError:
                     process.kill()
                 return None

--- a/custom_components/continuously_casting_dashboards/manifest.json
+++ b/custom_components/continuously_casting_dashboards/manifest.json
@@ -3,7 +3,7 @@
     "name": "Continuously Cast Dashboards",
     "documentation": "https://github.com/b0mbays/continuously_casting_dashboards",
     "requirements": ["catt==0.12.13"],
-    "version": "2.0.2",
+    "version": "2.0.3",
     "dependencies": [],
     "codeowners": ["@b0mbays"]
   }

--- a/custom_components/continuously_casting_dashboards/utils.py
+++ b/custom_components/continuously_casting_dashboards/utils.py
@@ -92,16 +92,16 @@ class SwitchEntityChecker:
         
         # Immediately log the switch entity config for diagnostics
         if self.switch_entity_id:
-            _LOGGER.debug(f"SWITCH ENTITY CONFIGURED: {self.switch_entity_id}")
+            _LOGGER.debug(f"GLOBAL SWITCH ENTITY CONFIGURED: {self.switch_entity_id}")
             
             # Check if the entity exists in Home Assistant
             state = self.hass.states.get(self.switch_entity_id)
             if state is None:
-                _LOGGER.error(f"CRITICAL: Switch entity {self.switch_entity_id} NOT FOUND in Home Assistant!")
+                _LOGGER.error(f"CRITICAL: Global switch entity {self.switch_entity_id} NOT FOUND in Home Assistant!")
             else:
-                _LOGGER.debug(f"SWITCH ENTITY CURRENT STATE: {state.state}")
+                _LOGGER.debug(f"GLOBAL SWITCH ENTITY CURRENT STATE: {state.state}")
         else:
-            _LOGGER.debug("NO SWITCH ENTITY CONFIGURED - Casting will always be enabled")
+            _LOGGER.debug("NO GLOBAL SWITCH ENTITY CONFIGURED - Casting will be controlled per device")
             
         # Also log the raw config for debugging
         if 'switch_entity_id' in config:
@@ -109,16 +109,31 @@ class SwitchEntityChecker:
         else:
             _LOGGER.debug("'switch_entity_id' not found in raw config. Check your configuration.yaml syntax.")
     
-    async def async_check_switch_entity(self):
+    async def async_check_switch_entity(self, device_name=None, device_config=None):
         """Check if the switch entity is enabled (if configured)."""
+        # First check device-specific switch entity if provided
+        if device_name and device_config and 'switch_entity_id' in device_config:
+            device_switch = device_config.get('switch_entity_id')
+            _LOGGER.debug(f"Checking device-specific switch entity for {device_name}: {device_switch}")
+            
+            if device_switch:
+                state = self.hass.states.get(device_switch)
+                if state is None:
+                    _LOGGER.warning(f"Device switch entity {device_switch} not found for {device_name}")
+                else:
+                    is_enabled = state.state.lower() in ('on', 'true', 'home', 'open')
+                    _LOGGER.debug(f"Device {device_name} - Switch Entity: {device_switch} state = {state.state}, casting enabled: {is_enabled}")
+                    return is_enabled
+        
+        # If no device-specific switch, use the global switch
         if not self.switch_entity_id:
-            return True  # No switch configured, always enabled
+            return True  # No global switch configured, enabled by default
         
         state = self.hass.states.get(self.switch_entity_id)
         if state is None:
-            _LOGGER.debug(f"Switch entity {self.switch_entity_id} not found in Home Assistant states")
+            _LOGGER.debug(f"Global switch entity {self.switch_entity_id} not found in Home Assistant states")
             return True  # If entity doesn't exist, default to enabled
         
-        is_enabled = state.state == 'on'
-        _LOGGER.debug(f"Continuously Casting Dashbords - Switch Entity: {self.switch_entity_id} state = {state.state}, casting enabled: {is_enabled}")
+        is_enabled = state.state.lower() in ('on', 'true', 'home', 'open')
+        _LOGGER.debug(f"Continuously Casting Dashboards - Global Switch Entity: {self.switch_entity_id} state = {state.state}, casting enabled: {is_enabled}")
         return is_enabled


### PR DESCRIPTION
- Fixed [issue](https://github.com/b0mbays/continuously_casting_dashboards/issues/103) where if a device that was set to connect via direct IP was offline, then the next device to be casted would either not work, or take over 10 minutes.
- New [feature](https://github.com/b0mbays/continuously_casting_dashboards/issues/105) to add a switch entity per device (as well as globally). This new switch per device will ignore any global switch entities.
- New feature to use a custom entity state for when casting is enabled.
- Removed [deprecated async call](https://github.com/b0mbays/continuously_casting_dashboards/issues/102) async_track_state_change and updated to async_track_state_change_event