### PR TITLE
Update readme (Use without external access)

### DIFF
--- a/custom_components/continuously_casting_dashboards/monitoring.py
+++ b/custom_components/continuously_casting_dashboards/monitoring.py
@@ -74,8 +74,8 @@ class MonitoringManager:
         
         # Register the listener for the global switch
         if self.switch_entity_id:
-            self.hass.helpers.event.async_track_state_change_event(
-                self.switch_entity_id, switch_state_listener
+            async_track_state_change_event(
+                self.hass, self.switch_entity_id, switch_state_listener
             )
             _LOGGER.info(f"Registered state change listener for global switch entity: {self.switch_entity_id}")
         
@@ -119,8 +119,8 @@ class MonitoringManager:
                                 self.hass.async_create_task(self.async_monitor_devices())
                         
                         # Register the listener for this device's switch
-                        self.hass.helpers.event.async_track_state_change_event(
-                            device_switch, device_switch_listener
+                        async_track_state_change_event(
+                            self.hass, device_switch, device_switch_listener
                         )
                         _LOGGER.info(f"Registered state change listener for device {device_name} switch entity: {device_switch}")
     async def async_stop_all_dashboards(self):

--- a/custom_components/continuously_casting_dashboards/utils.py
+++ b/custom_components/continuously_casting_dashboards/utils.py
@@ -3,7 +3,7 @@ import logging
 from datetime import time as dt_time, datetime
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
-from .const import DEFAULT_START_TIME, DEFAULT_END_TIME, CONF_SWITCH_ENTITY
+from .const import DEFAULT_START_TIME, DEFAULT_END_TIME, CONF_SWITCH_ENTITY, CONF_SWITCH_ENTITY_STATE
 
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
I validated that with a valid SSL certificate I can use this to cast successful to a Nest Hub 2 without issue. My instance is not externally accessible and I use Nginx Proxy Manager with a valid SSL certificate on a FQDN thats only locally resolvable and it was able to cast without issue :-) 

Not saying its required to merge if you do not want to but I do not think external access is required for advanced users so just wanted to document it.

```YAML
continuously_casting_dashboards:
  logging_level: warning #Required: Set the logging level - debug/info/warning (default is 'warning' - try 'debug' for debugging)
  cast_delay: 45 #Required: Time (in seconds) for casting checks between each device.
  start_time: "07:00" #Optional: Global start time of the casting window (format: "HH:MM") - Default is set to "07:00" and can be individually overwritten per device below.
  end_time: "01:00" #Optional: Global end time of the casting window (format: "HH:MM") and must be after "00:00". Default is set to "01:00" and can be individually overwritten per device below.
  devices:
    "<Display_Name>": #Required: Display name or IP address of your device. Find this on the actual device's settings or inside the Google Home app.
      - dashboard_url: "https://valid-ssl-cert-fqdn.com" #Required: Dashboard URL to be casted (This must be the local IP address of your HA instance, not homeassistant.local)
        volume: 5 #Optional: Volume to set the display. (If you remove this, the device will remain the same volume)
        start_time: "07:00" #Optional: Set the start time for this device
        end_time: "01:00" #Optional: Set the end time for this device
```