### PR TITLE
Improve status parsing and unreachable tracking

### DIFF
--- a/custom_components/continuously_casting_dashboards/device.py
+++ b/custom_components/continuously_casting_dashboards/device.py
@@ -157,7 +157,11 @@ class DeviceManager:
             "stopwatch",
             "countdown",
         ]
-        return any(keyword in sanitized for keyword in assistant_keywords)
+        for keyword in assistant_keywords:
+            if re.search(rf"\b{keyword}\b", sanitized):
+                _LOGGER.debug("Assistant activity keyword matched: '%s' in status output", keyword)
+                return True
+        return False
 
     async def _async_run_status_command(self, ip, timeout=TIMEOUT_STATUS_CHECK, allow_cache=True):
         """Run catt status and return stdout, stderr, return code, and a cache-hit flag.
@@ -314,13 +318,13 @@ class DeviceManager:
                 if "Scanning Chromecasts..." in line or not line.strip():
                     continue
 
-                # Parse format: IP - Name
-                parts = line.split(' - ')
+                # Parse format: IP - Name (name may itself contain " - ", so split on first only)
+                parts = line.split(' - ', 1)
                 if len(parts) < 2:
                     continue
 
                 ip = parts[0].strip()
-                found_name = parts[1].strip() if len(parts) > 1 else ""
+                found_name = parts[1].strip()
 
                 # Collect all found devices for logging
                 found_devices.append((found_name, ip))
@@ -526,7 +530,7 @@ class DeviceManager:
                     _LOGGER.debug("Device at %s is idle or not casting", ip)
                     return False
 
-                # Look for "Dummy" or our dashboard URL, which indicates our dashboard is casting
+                # Look for "Dummy" in the title, which indicates our dashboard is casting
                 if "Dummy" in output:
                     dummy_line = next((line for line in output.splitlines() if "Dummy" in line), "")
                     _LOGGER.debug("Dashboard found: %s", dummy_line)

--- a/custom_components/continuously_casting_dashboards/monitoring.py
+++ b/custom_components/continuously_casting_dashboards/monitoring.py
@@ -57,6 +57,7 @@ class MonitoringManager:
         self._device_locks: dict[str, asyncio.Lock] = {}  # Per-device locks for concurrent operations
         self._dummy_positions: dict = {}  # Reserved for future use
         self._unsubscribe_listeners: list = []  # Track listeners for cleanup
+        self._unreachable_counts: dict[str, int] = {}  # Consecutive unreachable cycle count per device
 
         # Set up switch entity state change listener if configured
         self.switch_entity_id = config.get(CONF_SWITCH_ENTITY)
@@ -483,9 +484,17 @@ class MonitoringManager:
                     return
                 
                 else:
-                    _LOGGER.info("Switch triggered but device %s has other content - marking status", device_name)
-                    # Device has other content, just update status
                     active_device = self.device_manager.get_active_device(device_key)
+                    previous_status = active_device.get('status') if active_device else None
+
+                    # If CCD itself stopped this device (e.g. switch was turned off), cast immediately
+                    # rather than waiting for the next regular monitoring cycle.
+                    if previous_status == 'stopped' and not is_unreachable:
+                        _LOGGER.info("Switch triggered and device %s was previously stopped by CCD - starting immediate cast", device_name)
+                        await self.async_start_device(device_name, current_config, ip)
+                        return
+
+                    _LOGGER.info("Switch triggered but device %s has other content - marking status", device_name)
                     if active_device:
                         self.device_manager.update_active_device(
                             device_key=device_key,
@@ -527,7 +536,8 @@ class MonitoringManager:
                         self.device_manager.update_active_device(device_key, 'connected', reconnect_attempts=0)
                         if self.stats_manager:
                             await self.stats_manager.async_update_health_stats(device_key, EVENT_RECONNECT_SUCCESS)
-                        # Dismiss any unreachable notification for this device
+                        # Dismiss any unreachable notification and reset the counter
+                        self._unreachable_counts.pop(device_key, None)
                         if self.config.get("enable_notifications", True):
                             notification_id = f"ccd_unreachable_{device_key.replace(' ', '_')}"
                             self.hass.async_create_task(
@@ -539,6 +549,7 @@ class MonitoringManager:
                     else:
                         self.device_manager.update_active_device(device_key, 'connected', last_checked=datetime.now().isoformat())
                 elif is_idle:
+                    self._unreachable_counts.pop(device_key, None)
                     # Device is idle, should show our dashboard
                     # Add a delay after any status change to prevent rapid reconnects
                     # This gives voice commands time to be processed
@@ -564,6 +575,9 @@ class MonitoringManager:
                             self.device_manager.update_active_device(device_key, 'disconnected', last_checked=datetime.now().isoformat())
                 elif is_unreachable:
                     # Device didn't respond at all — treat as disconnected, not other_content
+                    unreachable_count = self._unreachable_counts.get(device_key, 0) + 1
+                    self._unreachable_counts[device_key] = unreachable_count
+
                     if previous_status != 'disconnected':
                         _LOGGER.warning("Device %s (%s) is unreachable (all status checks timed out)", device_name, ip)
                         self.device_manager.update_active_device(
@@ -572,27 +586,29 @@ class MonitoringManager:
                             last_status_change=current_time,
                             last_checked=datetime.now().isoformat()
                         )
-                        if self.config.get("enable_notifications", True):
-                            notification_id = f"ccd_unreachable_{device_key.replace(' ', '_')}"
-                            self.hass.async_create_task(
-                                self.hass.services.async_call(
-                                    "persistent_notification", "create",
-                                    {
-                                        "title": f"CCD: {device_name} unreachable",
-                                        "message": (
-                                            f"**{device_name}** ({ip}) is not responding to status checks.\n\n"
-                                            f"The dashboard will resume automatically once the device comes back online. "
-                                            f"If this keeps happening, check the device's network connection."
-                                        ),
-                                        "notification_id": notification_id,
-                                    }
-                                )
-                            )
                     else:
-                        _LOGGER.debug("Device %s (%s) still unreachable", device_name, ip)
+                        _LOGGER.debug("Device %s (%s) still unreachable (consecutive count: %d)", device_name, ip, unreachable_count)
                         self.device_manager.update_active_device(device_key, 'disconnected', last_checked=datetime.now().isoformat())
+
+                    if unreachable_count == 5 and self.config.get("enable_notifications", True):
+                        notification_id = f"ccd_unreachable_{device_key.replace(' ', '_')}"
+                        self.hass.async_create_task(
+                            self.hass.services.async_call(
+                                "persistent_notification", "create",
+                                {
+                                    "title": f"CCD: {device_name} unreachable",
+                                    "message": (
+                                        f"**{device_name}** ({ip}) has not responded to the last 5 status checks.\n\n"
+                                        f"Try rebooting the device if it doesn't recover on its own. "
+                                        f"The dashboard will resume automatically once it comes back online."
+                                    ),
+                                    "notification_id": notification_id,
+                                }
+                            )
+                        )
                 else:
                     # Device has other content
+                    self._unreachable_counts.pop(device_key, None)
                     if previous_status != 'other_content':
                         self.device_manager.update_active_device(
                             device_key=device_key,


### PR DESCRIPTION
- Device name parsing fix: device names containing - (e.g. Google Nest - Kitchen) were being truncated at the first dash. Names are now parsed correctly regardless of how many dashes they contain.

- Unreachable notifications: the persistent notification for unreachable devices now only fires after 5 consecutive failed status checks, rather than on the first timeout. This avoids noisy alerts from brief network blips. The notification also now suggests rebooting the device.

- Switch entity responsiveness: when a switch or sensor entity turns back on (e.g. motion detected), CCD now casts immediately if it was the one that stopped the device - previously it would wait up to one full monitoring cycle before resuming.

- Assistant detection false positives: keywords like timer and alarm now use word-boundary matching, preventing partial matches against unrelated text in catt status output. The matched keyword is now logged at debug level to help diagnose any remaining false positives.