### PR TITLE
Added keepalive for Google TV. Utilized a 'remote' entity in HA

### DIFF
--- a/custom_components/continuously_casting_dashboards/config_flow.py
+++ b/custom_components/continuously_casting_dashboards/config_flow.py
@@ -18,6 +18,7 @@ import datetime
 from homeassistant.helpers import selector
 from homeassistant import config_entries
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.selector import EntitySelector, EntitySelectorConfig
 from homeassistant.config_entries import (
     ConfigEntry,
     ConfigFlowResult,
@@ -310,6 +311,7 @@ class ContinuouslyCastingDashboardsConfigFlow(config_entries.ConfigFlow, domain=
                 vol.Optional("switch_entity_id", default=""): cv.string,
                 vol.Optional("switch_entity_state", default=""): cv.string,
                 vol.Optional("enable_notifications", default=True): cv.boolean,
+                vol.Optional("remote_device_for_keepalive", description={"suggested_value": current.get("remote_device_for_keepalive")}): EntitySelector( EntitySelectorConfig(domain="remote")),
             }
         )
 
@@ -598,6 +600,10 @@ class DeviceSubentryFlow(ConfigSubentryFlow):
                 if user_input.get("volume") is not None:
                     cleaned_input["volume"] = user_input["volume"]
 
+                # Update the keepalive remote entity if provided
+                if user_input.get("remote_device_for_keepalive") is not None:
+                    cleaned_input["remote_device_for_keepalive"] = user_input["remote_device_for_keepalive"]
+
                 if user_input.get("enable_time_window", False):
                     if user_input.get("start_time"):
                         cleaned_input["start_time"] = user_input["start_time"]
@@ -666,6 +672,7 @@ class DeviceSubentryFlow(ConfigSubentryFlow):
                 vol.Optional("include_speaker_groups", default=False): cv.boolean,
                 vol.Optional("speaker_groups", default=""): cv.string,
                 vol.Optional("add_another", default=False): cv.boolean,
+                vol.Optional("remote_device_for_keepalive"): EntitySelector( EntitySelectorConfig(domain="remote")),  # filters to only remote.* entities
             }
         )
 
@@ -929,6 +936,10 @@ class DeviceSubentryFlow(ConfigSubentryFlow):
                 else:
                     cleaned_input["dashboard_url"] = dashboard_url
 
+                # Update the keepalive remote entity if provided
+                if user_input.get("remote_device_for_keepalive") is not None:
+                    cleaned_input["remote_device_for_keepalive"] = user_input["remote_device_for_keepalive"]
+
                 if user_input.get("volume") is not None:
                     cleaned_input["volume"] = user_input["volume"]
 
@@ -971,7 +982,6 @@ class DeviceSubentryFlow(ConfigSubentryFlow):
 
                     if add_another:
                         return await self.async_step_reconfigure_add_dashboard()
-
                     return self._save_reconfigure()
 
             except Exception as ex:
@@ -1035,6 +1045,7 @@ class DeviceSubentryFlow(ConfigSubentryFlow):
             ): cv.string,
             vol.Optional("include_speaker_groups", default=has_groups): cv.boolean,
             vol.Optional("speaker_groups", default=speaker_groups_str): cv.string,
+            vol.Optional("remote_device_for_keepalive", description={"suggested_value": current.get("remote_device_for_keepalive")}): EntitySelector( EntitySelectorConfig(domain="remote")),
         }
 
         if len(self._dashboards) > 1:
@@ -1098,6 +1109,10 @@ class DeviceSubentryFlow(ConfigSubentryFlow):
                 speaker_groups = [g.strip() for g in speaker_groups_input.split(",") if g.strip()]
                 if speaker_groups:
                     cleaned_input["speaker_groups"] = speaker_groups
+
+        # Update the keepalive remote entity if provided
+        if user_input.get("remote_device_for_keepalive") is not None:
+            cleaned_input["remote_device_for_keepalive"] = user_input.get("remote_device_for_keepalive")
 
         # Update device identifier fields if provided
         new_device_name = user_input.get("device_name", "").strip()
@@ -1192,6 +1207,10 @@ class DeviceSubentryFlow(ConfigSubentryFlow):
                 if user_input.get("volume") is not None:
                     cleaned_input["volume"] = user_input["volume"]
 
+                # Update the keepalive remote entity if provided
+                if user_input.get("remote_device_for_keepalive") is not None:
+                    cleaned_input["remote_device_for_keepalive"] = user_input["remote_device_for_keepalive"]
+
                 if user_input.get("enable_time_window", False):
                     if user_input.get("start_time"):
                         cleaned_input["start_time"] = user_input["start_time"]
@@ -1257,6 +1276,7 @@ class DeviceSubentryFlow(ConfigSubentryFlow):
                 vol.Optional("switch_entity_state", default=""): cv.string,
                 vol.Optional("include_speaker_groups", default=False): cv.boolean,
                 vol.Optional("speaker_groups", default=""): cv.string,
+                vol.Optional("remote_device_for_keepalive"): EntitySelector( EntitySelectorConfig(domain="remote")),  # filters to only remote.* entities
             }
         )
 

--- a/custom_components/continuously_casting_dashboards/monitoring.py
+++ b/custom_components/continuously_casting_dashboards/monitoring.py
@@ -231,6 +231,20 @@ class MonitoringManager:
             # Process this single device using the same logic as the main monitoring
             await self._process_single_device(target_device_name, ip, current_config, force_check=True)
 
+    """Send the keeyalive keypress to a Google TV using the provided remote entity."""
+    async def _send_keepalive_button(self, remote_entity_id: str):
+        if remote_entity_id is None:
+            return
+
+        _LOGGER.debug("Sending keepalive using: " + remote_entity_id)
+        await self.hass.services.async_call(
+            domain="remote",
+            service="send_command",
+            service_data={"command": "MENU"},
+            target={"entity_id": remote_entity_id},
+            blocking=True,
+        )
+
     async def _process_single_device(self, device_name, ip, current_config, force_check=False):
             """Evaluate device state and cast, stop, or skip as appropriate.
 
@@ -523,7 +537,6 @@ class MonitoringManager:
                 
                 # Determine current state and take appropriate action
                 if is_casting:  # Use the single status check result
-
                     # Device is showing our dashboard
                     if previous_status != 'connected':
                         self.device_manager.update_active_device(
@@ -547,6 +560,7 @@ class MonitoringManager:
                                 )
                             )
                     else:
+                        await self._send_keepalive_button(current_config.get("remote_device_for_keepalive"));   
                         self.device_manager.update_active_device(device_key, 'connected', last_checked=datetime.now().isoformat())
                 elif is_idle:
                     self._unreachable_counts.pop(device_key, None)

--- a/custom_components/continuously_casting_dashboards/translations/en.json
+++ b/custom_components/continuously_casting_dashboards/translations/en.json
@@ -113,7 +113,8 @@
                         "switch_entity_state": "Required State",
                         "include_speaker_groups": "Pause casting when a speaker group is active",
                         "speaker_groups": "Speaker Group Names",
-                        "add_another": "Add another dashboard after this one"
+                        "add_another": "Add another dashboard after this one",
+                        "remote_device_for_keepalive": "Entity to use for keepalive (Remote)"
                     },
                     "data_description": {
                         "dashboard_url": "Full URL (e.g., http://192.168.1.100:8123/lovelace/home?kiosk)",
@@ -122,7 +123,8 @@
                         "end_time": "24-hour format — the dashboard stops casting at this time each day",
                         "switch_entity_id": "Entity that enables or disables casting for this device",
                         "switch_entity_state": "State that enables casting. Leave blank for defaults (on, true, home, open)",
-                        "speaker_groups": "Comma-separated list of speaker group names to check"
+                        "speaker_groups": "Comma-separated list of speaker group names to check",
+                        "remote_device_for_keepalive": "Use this device to send Keepalive messages.  Prevents Google TV Ambient Screensaver."
                     }
                 },
                 "reconfigure_device": {
@@ -144,7 +146,8 @@
                         "speaker_groups": "Speaker Group Names",
                         "add_another_dashboard": "Add another dashboard after saving",
                         "change_dashboard": "Edit a different dashboard",
-                        "delete_this_dashboard": "Delete this dashboard"
+                        "delete_this_dashboard": "Delete this dashboard",
+                        "remote_device_for_keepalive": "Entity to use for keepalive (Remote)"
                     },
                     "data_description": {
                         "device_name": "Chromecast name from Google Home (e.g., 'Living Room Display')",
@@ -159,7 +162,8 @@
                         "speaker_groups": "Comma-separated list of speaker group names to check",
                         "add_another_dashboard": "Saves this dashboard and opens a blank form for another one",
                         "change_dashboard": "Save your changes and pick a different dashboard to edit",
-                        "delete_this_dashboard": "Remove this dashboard (cannot delete the last one)"
+                        "delete_this_dashboard": "Remove this dashboard (cannot delete the last one)",
+                        "remote_device_for_keepalive": "Use this device to send Keepalive messages.  Prevents Google TV Ambient Screensaver."
                     }
                 },
                 "reconfigure_select_dashboard": {
@@ -189,7 +193,8 @@
                         "switch_entity_id": "Control Entity ID",
                         "switch_entity_state": "Required State",
                         "include_speaker_groups": "Pause casting when a speaker group is active",
-                        "speaker_groups": "Speaker Group Names"
+                        "speaker_groups": "Speaker Group Names",
+                        "remote_device_for_keepalive": "Entity to use for keepalive (Remote)"
                     },
                     "data_description": {
                         "dashboard_url": "Full URL (e.g., http://192.168.1.100:8123/lovelace/home?kiosk)",
@@ -198,7 +203,8 @@
                         "end_time": "24-hour format — the dashboard stops casting at this time each day",
                         "switch_entity_id": "Entity that enables or disables casting for this device",
                         "switch_entity_state": "State that enables casting. Leave blank for defaults (on, true, home, open)",
-                        "speaker_groups": "Comma-separated list of speaker group names to check"
+                        "speaker_groups": "Comma-separated list of speaker group names to check",
+                        "remote_device_for_keepalive": "Use this device to send Keepalive messages.  Prevents Google TV Ambient Screensaver."
                     }
                 }
             },


### PR DESCRIPTION
Was having this issue, https://github.com/b0mbays/continuously_casting_dashboards/issues/151, where the Ambient Screensaver would kick in on Google TV and none of the catt information or statuses would update.  This PR adds an optional config of a 'remote' entity in HA.  If it's set, a keepalive command ('MENU') is sent to the Google TV device to keep the screensaver from kicking in.